### PR TITLE
Add support for indexing Apache Phoenix data

### DIFF
--- a/hbase-indexer-all/pom.xml
+++ b/hbase-indexer-all/pom.xml
@@ -46,6 +46,10 @@
       <groupId>com.ngdata</groupId>
       <artifactId>hbase-sep-tools</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.ngdata</groupId>
+      <artifactId>hbase-indexer-phoenix</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/hbase-indexer-phoenix/README.md
+++ b/hbase-indexer-phoenix/README.md
@@ -1,0 +1,16 @@
+Phoenix HBase Indexer plugins
+=============================
+
+A set of plugin ByteArrayValueMappers to allow using hbase-indexer to index data stored
+in [Apache Phoenix](http://phoenix.apache.org).
+
+Usage involves supplying the include ByteArrayValueMapper implementation class names for the `type` attribute in a
+`field` definition in an indexer definition. For example, to index the `COMPANY` field of the `STOCK_SYMBOL` in the
+Phoenix samples, you would set up an hbase-indexer configuration as follows:
+
+    <indexer table="STOCK_SYMBOL"
+      <field name="COMPANY" 
+             value="0:COMPANY" 
+             type="com.ngdata.hbaseindexer.phoenix.VarcharMapper"/>
+    </indexer>
+

--- a/hbase-indexer-phoenix/pom.xml
+++ b/hbase-indexer-phoenix/pom.xml
@@ -1,0 +1,53 @@
+<!--
+  ~ Copyright 2014 NGDATA nv
+  ~
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>hbase-indexer-phoenix</artifactId>
+  <name>HBase Indexer: Apache Phoenix record mapper</name>
+
+  <parent>
+    <groupId>com.ngdata</groupId>
+    <artifactId>hbase-indexer</artifactId>
+    <version>1.6-SNAPSHOT</version>
+    <relativePath>..</relativePath>
+  </parent>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.ngdata</groupId>
+      <artifactId>hbase-indexer-engine</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.phoenix</groupId>
+      <artifactId>phoenix-core</artifactId>
+      <!-- Don't automatically package Phoenix, and don't pull
+           in all its dependencies to this build -->
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/hbase-indexer-phoenix/src/main/java/com/ngdata/hbaseindexer/phoenix/AbstractFixedWidthMapper.java
+++ b/hbase-indexer-phoenix/src/main/java/com/ngdata/hbaseindexer/phoenix/AbstractFixedWidthMapper.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2014 NGDATA nv
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ngdata.hbaseindexer.phoenix;
+
+import com.google.common.collect.ImmutableList;
+import com.ngdata.hbaseindexer.parse.ByteArrayValueMapper;
+import org.apache.phoenix.schema.PDataType;
+
+import java.util.Collection;
+
+/**
+ * Base class for all fixed-width types.
+ */
+abstract class AbstractFixedWidthMapper implements ByteArrayValueMapper {
+
+    private final PDataType dataType;
+
+    protected AbstractFixedWidthMapper(PDataType dataType) {
+        this.dataType = dataType;
+    }
+
+    @Override
+    public Collection<? extends Object> map(byte[] bytes) {
+        Object value = dataType.toObject(bytes, bytes.length - dataType.getByteSize(), dataType.getByteSize());
+        return ImmutableList.of(value);
+    }
+}

--- a/hbase-indexer-phoenix/src/main/java/com/ngdata/hbaseindexer/phoenix/AbstractUniqueKeyFormatter.java
+++ b/hbase-indexer-phoenix/src/main/java/com/ngdata/hbaseindexer/phoenix/AbstractUniqueKeyFormatter.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2014 NGDATA nv
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ngdata.hbaseindexer.phoenix;
+
+import com.google.common.collect.Iterables;
+import com.ngdata.hbaseindexer.parse.ByteArrayValueMapper;
+import com.ngdata.hbaseindexer.uniquekey.UniqueKeyFormatter;
+import org.apache.hadoop.hbase.KeyValue;
+
+import java.util.Arrays;
+
+
+abstract class AbstractUniqueKeyFormatter implements UniqueKeyFormatter {
+
+    private final ByteArrayValueMapper byteArrayValueMapper;
+
+
+    protected AbstractUniqueKeyFormatter(ByteArrayValueMapper byteArrayValueMapper) {
+        this.byteArrayValueMapper = byteArrayValueMapper;
+    }
+
+    @Override
+    public final String formatRow(byte[] row) {
+        Object formatted = Iterables.getFirst(byteArrayValueMapper.map(row), null);
+        if (formatted == null) {
+            throw new IllegalStateException("Formatted row was null from " + Arrays.toString(row));
+        }
+        return String.valueOf(formatted);
+    }
+
+    @Override
+    public String formatFamily(byte[] family) {
+        throw new UnsupportedOperationException("formatFamily is not supported");
+    }
+
+    @Override
+    public String formatKeyValue(KeyValue keyValue) {
+        throw new UnsupportedOperationException("formatKeyValue is not supported");
+    }
+
+    @Override
+    public byte[] unformatRow(String keyString) {
+        throw new UnsupportedOperationException("Unformatting is not supported");
+    }
+
+    @Override
+    public byte[] unformatFamily(String familyString) {
+        throw new UnsupportedOperationException("Unformatting is not supported");
+    }
+
+    @Override
+    public KeyValue unformatKeyValue(String keyValueString) {
+        throw new UnsupportedOperationException("Unformatting is not supported");
+    }
+}

--- a/hbase-indexer-phoenix/src/main/java/com/ngdata/hbaseindexer/phoenix/CharLongKeyFormatter.java
+++ b/hbase-indexer-phoenix/src/main/java/com/ngdata/hbaseindexer/phoenix/CharLongKeyFormatter.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2014 NGDATA nv
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ngdata.hbaseindexer.phoenix;
+
+/**
+ * @see com.ngdata.hbaseindexer.phoenix.CharLongKeyFormatter
+ */
+public class CharLongKeyFormatter  extends AbstractUniqueKeyFormatter {
+
+    public CharLongKeyFormatter() {
+        super(new CharLongMapper());
+    }
+}
+

--- a/hbase-indexer-phoenix/src/main/java/com/ngdata/hbaseindexer/phoenix/CharLongMapper.java
+++ b/hbase-indexer-phoenix/src/main/java/com/ngdata/hbaseindexer/phoenix/CharLongMapper.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014 NGDATA nv
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ngdata.hbaseindexer.phoenix;
+
+import com.google.common.collect.ImmutableList;
+import com.ngdata.hbaseindexer.parse.ByteArrayValueMapper;
+import org.apache.phoenix.schema.PDataType;
+
+import java.util.Collection;
+
+/**
+ * Formats a Phoenix row key consisting of a CHAR(1) and a BIGINT into the string concatenation of these
+ * two.
+ *
+ * <p>The use-case are the multitenant Lily keys, where the tenant is a CHAR(1).</p>
+ */
+public class CharLongMapper implements ByteArrayValueMapper {
+    @Override
+    public Collection<? extends Object> map(byte[] bytes) {
+        PDataType longDataType = PDataType.LONG;
+        PDataType charDataType = PDataType.CHAR;
+        int charLength = 1;
+
+        Object longValue = longDataType.toObject(bytes, bytes.length - longDataType.getByteSize(), longDataType.getByteSize());
+        Object charValue = charDataType.toObject(bytes, bytes.length - longDataType.getByteSize() - charLength, charLength);
+
+        return ImmutableList.of(charValue.toString() + longValue.toString());
+    }
+}

--- a/hbase-indexer-phoenix/src/main/java/com/ngdata/hbaseindexer/phoenix/DateKeyFormatter.java
+++ b/hbase-indexer-phoenix/src/main/java/com/ngdata/hbaseindexer/phoenix/DateKeyFormatter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2014 NGDATA nv
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ngdata.hbaseindexer.phoenix;
+
+/**
+ * A unique key formatter for converting Phoenix long key fields from bytes into long.
+ * <p/>
+ * Note: this key formatter is one-way only, and can only be used for row-based indexing.
+ */
+public class DateKeyFormatter extends AbstractUniqueKeyFormatter {
+
+    public DateKeyFormatter() {
+        super(new DateMapper());
+    }
+}

--- a/hbase-indexer-phoenix/src/main/java/com/ngdata/hbaseindexer/phoenix/DateMapper.java
+++ b/hbase-indexer-phoenix/src/main/java/com/ngdata/hbaseindexer/phoenix/DateMapper.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2014 NGDATA nv
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ngdata.hbaseindexer.phoenix;
+
+import org.apache.phoenix.schema.PDataType;
+
+public class DateMapper extends AbstractFixedWidthMapper {
+    public DateMapper() {
+        super(PDataType.DATE);
+    }
+}

--- a/hbase-indexer-phoenix/src/main/java/com/ngdata/hbaseindexer/phoenix/DoubleMapper.java
+++ b/hbase-indexer-phoenix/src/main/java/com/ngdata/hbaseindexer/phoenix/DoubleMapper.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2014 NGDATA nv
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ngdata.hbaseindexer.phoenix;
+
+
+import org.apache.phoenix.schema.PDataType;
+
+/**
+ * {@code ByteArrayDoubleMapper} for {@code DOUBLE} values.
+ */
+public class DoubleMapper extends AbstractFixedWidthMapper {
+    public DoubleMapper() {
+        super(PDataType.DOUBLE);
+    }
+}

--- a/hbase-indexer-phoenix/src/main/java/com/ngdata/hbaseindexer/phoenix/IntegerKeyFormatter.java
+++ b/hbase-indexer-phoenix/src/main/java/com/ngdata/hbaseindexer/phoenix/IntegerKeyFormatter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2014 NGDATA nv
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ngdata.hbaseindexer.phoenix;
+
+
+/**
+ * A unique key formatter for converting Phoenix integer key fields from bytes into integer.
+ * <p/>
+ * Note: this key formatter is one-way only, and can only be used for row-based indexing.
+ */
+public class IntegerKeyFormatter extends AbstractUniqueKeyFormatter {
+    public IntegerKeyFormatter() {
+        super(new IntegerMapper());
+    }
+}

--- a/hbase-indexer-phoenix/src/main/java/com/ngdata/hbaseindexer/phoenix/IntegerMapper.java
+++ b/hbase-indexer-phoenix/src/main/java/com/ngdata/hbaseindexer/phoenix/IntegerMapper.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2014 NGDATA nv
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ngdata.hbaseindexer.phoenix;
+
+import org.apache.phoenix.schema.PDataType;
+
+/**
+ * {@code ByteArrayDoubleMapper} for {@code INTEGER} values.
+ */
+public class IntegerMapper extends AbstractFixedWidthMapper {
+    public IntegerMapper() {
+        super(PDataType.INTEGER);
+    }
+}

--- a/hbase-indexer-phoenix/src/main/java/com/ngdata/hbaseindexer/phoenix/LongArrayMapper.java
+++ b/hbase-indexer-phoenix/src/main/java/com/ngdata/hbaseindexer/phoenix/LongArrayMapper.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014 NGDATA nv
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ngdata.hbaseindexer.phoenix;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Longs;
+import com.ngdata.hbaseindexer.parse.ByteArrayValueMapper;
+import org.apache.phoenix.schema.PDataType;
+
+import java.sql.Array;
+import java.sql.SQLException;
+import java.util.Collection;
+
+/**
+ * {@link com.ngdata.hbaseindexer.parse.ByteArrayValueMapper} for {@link org.apache.phoenix.schema.PDataType#LONG_ARRAY} values.
+ */
+public class LongArrayMapper implements ByteArrayValueMapper {
+    @Override
+    public Collection<? extends Object> map(byte[] bytes) {
+        Array values = (Array)PDataType.LONG_ARRAY.toObject(bytes);
+        if (values == null) {
+            return ImmutableList.of();
+        } else {
+            try {
+                return Longs.asList((long[])values.getArray());
+            } catch (SQLException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/hbase-indexer-phoenix/src/main/java/com/ngdata/hbaseindexer/phoenix/LongKeyFormatter.java
+++ b/hbase-indexer-phoenix/src/main/java/com/ngdata/hbaseindexer/phoenix/LongKeyFormatter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2014 NGDATA nv
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ngdata.hbaseindexer.phoenix;
+
+/**
+ * A unique key formatter for converting Phoenix long key fields from bytes into long.
+ * <p/>
+ * Note: this key formatter is one-way only, and can only be used for row-based indexing.
+ */
+public class LongKeyFormatter extends AbstractUniqueKeyFormatter {
+
+    public LongKeyFormatter() {
+        super(new LongMapper());
+    }
+}

--- a/hbase-indexer-phoenix/src/main/java/com/ngdata/hbaseindexer/phoenix/LongMapper.java
+++ b/hbase-indexer-phoenix/src/main/java/com/ngdata/hbaseindexer/phoenix/LongMapper.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2014 NGDATA nv
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ngdata.hbaseindexer.phoenix;
+
+import org.apache.phoenix.schema.PDataType;
+
+/**
+ * {@code ByteArrayDoubleMapper} for {@code LONG} values.
+ */
+public class LongMapper extends AbstractFixedWidthMapper {
+    public LongMapper() {
+        super(PDataType.LONG);
+    }
+}

--- a/hbase-indexer-phoenix/src/main/java/com/ngdata/hbaseindexer/phoenix/VarcharArrayMapper.java
+++ b/hbase-indexer-phoenix/src/main/java/com/ngdata/hbaseindexer/phoenix/VarcharArrayMapper.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014 NGDATA nv
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ngdata.hbaseindexer.phoenix;
+
+import com.google.common.collect.ImmutableList;
+import com.ngdata.hbaseindexer.parse.ByteArrayValueMapper;
+import org.apache.phoenix.schema.PDataType;
+
+import java.sql.Array;
+import java.sql.SQLException;
+import java.util.Collection;
+
+/**
+ * {@link ByteArrayValueMapper} for {@link PDataType#VARCHAR_ARRAY} values.
+ */
+public class VarcharArrayMapper implements ByteArrayValueMapper {
+    @Override
+    public Collection<? extends Object> map(byte[] bytes) {
+        Array values = (java.sql.Array)PDataType.VARCHAR_ARRAY.toObject(bytes);
+        if (values == null) {
+            return ImmutableList.of();
+        } else {
+            try {
+                return ImmutableList.copyOf((String[])values.getArray());
+            } catch (SQLException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/hbase-indexer-phoenix/src/main/java/com/ngdata/hbaseindexer/phoenix/VarcharKeyFormatter.java
+++ b/hbase-indexer-phoenix/src/main/java/com/ngdata/hbaseindexer/phoenix/VarcharKeyFormatter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2014 NGDATA nv
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ngdata.hbaseindexer.phoenix;
+
+
+/**
+ * A unique key formatter for converting Phoenix varchar key fields from bytes into varchar.
+ * <p/>
+ * Note: this key formatter is one-way only, and can only be used for row-based indexing.
+ */
+public class VarcharKeyFormatter extends AbstractUniqueKeyFormatter {
+    public VarcharKeyFormatter() {
+        super(new VarcharMapper());
+    }
+}

--- a/hbase-indexer-phoenix/src/main/java/com/ngdata/hbaseindexer/phoenix/VarcharMapper.java
+++ b/hbase-indexer-phoenix/src/main/java/com/ngdata/hbaseindexer/phoenix/VarcharMapper.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014 NGDATA nv
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ngdata.hbaseindexer.phoenix;
+
+import com.google.common.collect.ImmutableList;
+import com.ngdata.hbaseindexer.parse.ByteArrayValueMapper;
+import org.apache.phoenix.schema.PDataType;
+
+import java.util.Collection;
+
+/**
+ * {@code ByteArrayDoubleMapper} for {@code VARCHAR} values.
+ */
+public class VarcharMapper implements ByteArrayValueMapper {
+    @Override
+    public Collection<? extends Object> map(byte[] bytes) {
+        Object value = PDataType.VARCHAR.toObject(bytes);
+        if (value == null) {
+            return ImmutableList.of();
+        } else {
+            return ImmutableList.of(value);
+        }
+    }
+}

--- a/hbase-indexer-phoenix/src/test/java/com/ngdata/hbaseindexer/phoenix/DateMapperTest.java
+++ b/hbase-indexer-phoenix/src/test/java/com/ngdata/hbaseindexer/phoenix/DateMapperTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2014 NGDATA nv
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ngdata.hbaseindexer.phoenix;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.phoenix.schema.PDataType;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class DateMapperTest {
+
+    private DateMapper mapper = new DateMapper();
+
+    private DateTime now = new DateTime(DateTimeZone.UTC);
+
+    @Test
+    public void testMap() {
+        assertEquals(
+                ImmutableList.of(now.toDate()),
+                mapper.map(PDataType.DATE.toBytes(now.toDate())));
+    }
+
+    @Test
+    public void testMap_EndOfCompositeValue() {
+        byte[] buffer = new byte[PDataType.DATE.getByteSize() + 2];
+        PDataType.DATE.toBytes(now.toDate(), buffer, 2);
+        assertEquals(
+                ImmutableList.of(now.toDate()),
+                mapper.map(buffer));
+    }
+}

--- a/hbase-indexer-phoenix/src/test/java/com/ngdata/hbaseindexer/phoenix/DoubleMapperTest.java
+++ b/hbase-indexer-phoenix/src/test/java/com/ngdata/hbaseindexer/phoenix/DoubleMapperTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014 NGDATA nv
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ngdata.hbaseindexer.phoenix;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.phoenix.schema.PDataType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class DoubleMapperTest {
+
+    private DoubleMapper mapper = new DoubleMapper();
+
+    @Test
+    public void testMap() {
+        assertEquals(
+                ImmutableList.of(Math.PI),
+                mapper.map(PDataType.DOUBLE.toBytes(Math.PI)));
+    }
+
+    @Test
+    public void testMap_EndOfCompositeValue() {
+        byte[] buffer = new byte[PDataType.DOUBLE.getByteSize() + 2];
+        PDataType.DOUBLE.toBytes(Math.PI, buffer, 2);
+        assertEquals(
+                ImmutableList.of(Math.PI),
+                mapper.map(buffer));
+    }
+}

--- a/hbase-indexer-phoenix/src/test/java/com/ngdata/hbaseindexer/phoenix/IntegerKeyFormatterTest.java
+++ b/hbase-indexer-phoenix/src/test/java/com/ngdata/hbaseindexer/phoenix/IntegerKeyFormatterTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014 NGDATA nv
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ngdata.hbaseindexer.phoenix;
+
+import org.apache.phoenix.schema.PDataType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class IntegerKeyFormatterTest {
+
+    @Test
+    public void testFormatRow() {
+        assertEquals("42", new IntegerKeyFormatter().formatRow(PDataType.INTEGER.toBytes(42)));
+    }
+}

--- a/hbase-indexer-phoenix/src/test/java/com/ngdata/hbaseindexer/phoenix/IntegerMapperTest.java
+++ b/hbase-indexer-phoenix/src/test/java/com/ngdata/hbaseindexer/phoenix/IntegerMapperTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014 NGDATA nv
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ngdata.hbaseindexer.phoenix;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.phoenix.schema.PDataType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class IntegerMapperTest {
+
+    private IntegerMapper mapper = new IntegerMapper();
+
+    @Test
+    public void testMap() {
+        assertEquals(
+                ImmutableList.of(42),
+                mapper.map(PDataType.INTEGER.toBytes(42)));
+    }
+
+    @Test
+    public void testMap_EndOfCompositeValue() {
+        byte[] buffer = new byte[PDataType.INTEGER.getByteSize() + 2];
+        PDataType.INTEGER.toBytes(42, buffer, 2);
+
+        assertEquals(
+                ImmutableList.of(42),
+                mapper.map(buffer));
+    }
+
+}

--- a/hbase-indexer-phoenix/src/test/java/com/ngdata/hbaseindexer/phoenix/LongArrayMapperTest.java
+++ b/hbase-indexer-phoenix/src/test/java/com/ngdata/hbaseindexer/phoenix/LongArrayMapperTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014 NGDATA nv
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ngdata.hbaseindexer.phoenix;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.phoenix.schema.PDataType;
+import org.apache.phoenix.schema.PhoenixArray;
+import org.apache.phoenix.util.ByteUtil;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class LongArrayMapperTest {
+    private LongArrayMapper mapper = new LongArrayMapper();
+
+    @Test
+    public void testMap() {
+        PhoenixArray array = new PhoenixArray(PDataType.LONG, new Long[] { 1L, 10L, 100L });
+        assertEquals(
+                ImmutableList.of(1L, 10L, 100L),
+                mapper.map(PDataType.LONG_ARRAY.toBytes(array)));
+    }
+
+    @Test
+    public void testMapNull() {
+        assertEquals(
+                ImmutableList.of(),
+                mapper.map(ByteUtil.EMPTY_BYTE_ARRAY));
+    }
+}

--- a/hbase-indexer-phoenix/src/test/java/com/ngdata/hbaseindexer/phoenix/LongKeyFormatterTest.java
+++ b/hbase-indexer-phoenix/src/test/java/com/ngdata/hbaseindexer/phoenix/LongKeyFormatterTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014 NGDATA nv
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ngdata.hbaseindexer.phoenix;
+
+import org.apache.phoenix.schema.PDataType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class LongKeyFormatterTest {
+
+    @Test
+    public void testFormatRow() {
+        assertEquals("42", new LongKeyFormatter().formatRow(PDataType.LONG.toBytes(42L)));
+    }
+
+}

--- a/hbase-indexer-phoenix/src/test/java/com/ngdata/hbaseindexer/phoenix/LongMapperTest.java
+++ b/hbase-indexer-phoenix/src/test/java/com/ngdata/hbaseindexer/phoenix/LongMapperTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2014 NGDATA nv
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ngdata.hbaseindexer.phoenix;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.phoenix.schema.PDataType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class LongMapperTest {
+
+    private LongMapper mapper = new LongMapper();
+
+    @Test
+    public void testMap() {
+        assertEquals(
+                ImmutableList.of(42L),
+                mapper.map(PDataType.LONG.toBytes(42L)));
+
+    }
+
+    @Test
+    public void testMap_EndOfCompositeValue() {
+        byte[] buffer = new byte[PDataType.LONG.getByteSize() + 2];
+        PDataType.LONG.toBytes(42L, buffer, 2);
+
+        assertEquals(
+                ImmutableList.of(42L),
+                mapper.map(buffer));
+    }
+
+}

--- a/hbase-indexer-phoenix/src/test/java/com/ngdata/hbaseindexer/phoenix/VarcharArrayMapperTest.java
+++ b/hbase-indexer-phoenix/src/test/java/com/ngdata/hbaseindexer/phoenix/VarcharArrayMapperTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014 NGDATA nv
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ngdata.hbaseindexer.phoenix;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.phoenix.schema.PDataType;
+import org.apache.phoenix.schema.PhoenixArray;
+import org.apache.phoenix.util.ByteUtil;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class VarcharArrayMapperTest {
+    private VarcharArrayMapper mapper = new VarcharArrayMapper();
+
+    @Test
+    public void testMap() {
+        PhoenixArray array = new PhoenixArray(PDataType.VARCHAR, new String[]{"a", "b", "c"});
+        assertEquals(
+                ImmutableList.of("a", "b", "c"),
+                mapper.map(PDataType.VARCHAR_ARRAY.toBytes(array)));
+    }
+
+    @Test
+    public void testMapNull() {
+        assertEquals(
+                ImmutableList.of(),
+                mapper.map(ByteUtil.EMPTY_BYTE_ARRAY));
+    }
+}

--- a/hbase-indexer-phoenix/src/test/java/com/ngdata/hbaseindexer/phoenix/VarcharKeyFormatterTest.java
+++ b/hbase-indexer-phoenix/src/test/java/com/ngdata/hbaseindexer/phoenix/VarcharKeyFormatterTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014 NGDATA nv
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ngdata.hbaseindexer.phoenix;
+
+import org.apache.phoenix.schema.PDataType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class VarcharKeyFormatterTest {
+
+    @Test
+    public void testFormatRow() {
+        assertEquals("forty-two", new VarcharKeyFormatter().formatRow(PDataType.VARCHAR.toBytes("forty-two")));
+    }
+
+}

--- a/hbase-indexer-phoenix/src/test/java/com/ngdata/hbaseindexer/phoenix/VarcharMapperTest.java
+++ b/hbase-indexer-phoenix/src/test/java/com/ngdata/hbaseindexer/phoenix/VarcharMapperTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014 NGDATA nv
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ngdata.hbaseindexer.phoenix;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.phoenix.schema.PDataType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class VarcharMapperTest {
+
+    private VarcharMapper mapper = new VarcharMapper();
+
+    @Test
+    public void testMap() {
+        assertEquals(
+                ImmutableList.of("TestValue"),
+                mapper.map(PDataType.VARCHAR.toBytes("TestValue")));
+    }
+
+    @Test
+    public void testMapNull() {
+        assertEquals(
+                ImmutableList.of(),
+                mapper.map(PDataType.VARCHAR.toBytes(null)));
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
     <version.search>1.2.0</version.search>
     <version.search.hbase98>1.0.0-cdh5.0.0</version.search.hbase98>
     <version.jersey>1.17</version.jersey>
+    <version.phoenix>4.2.2</version.phoenix>
 
     <!-- Tells maven plugins what file encoding to use -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -74,13 +75,14 @@
     <module>hbase-indexer-common</module>
     <module>hbase-indexer-model</module>
     <module>hbase-indexer-cli</module>
-    <module>hbase-indexer-all</module>
     <module>hbase-indexer-engine</module>
     <module>hbase-indexer-morphlines</module>
+    <module>hbase-indexer-phoenix</module>
     <module>hbase-indexer-demo</module>
     <module>hbase-sep</module>
     <module>hbase-indexer-mr</module>
     <module>hbase-indexer-dist</module>
+    <module>hbase-indexer-all</module>
   </modules>
 
   <dependencyManagement>
@@ -168,6 +170,11 @@
       <dependency>
         <groupId>com.ngdata</groupId>
         <artifactId>hbase-indexer-all</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.ngdata</groupId>
+        <artifactId>hbase-indexer-phoenix</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
@@ -427,6 +434,11 @@
         <groupId>org.kohsuke</groupId>
         <artifactId>akuma</artifactId>
         <version>1.9</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.phoenix</groupId>
+        <artifactId>phoenix-core</artifactId>
+        <version>${version.phoenix}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Include ByteArrayValueMappers and UniqueKeyFormatters for
indexing data that has been encoded by Apache Phoenix.
