### PR TITLE
LWSHADOOP-729: Upgrade akuma dependency to v1.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -468,7 +468,7 @@
       <dependency>
         <groupId>org.kohsuke</groupId>
         <artifactId>akuma</artifactId>
-        <version>1.9</version>
+        <version>1.10</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
- JNA v3.4.0 dependency which is shipped by lucidworks-hdpsearch is LGPL license and is incompatible with Apache License