### PR TITLE
LWSHADOOP-736: Update hbase-indexer to use Solr 6.6.2

### DIFF
--- a/hbase-indexer-common/src/main/java/com/ngdata/hbaseindexer/util/solr/SolrConfigLoader.java
+++ b/hbase-indexer-common/src/main/java/com/ngdata/hbaseindexer/util/solr/SolrConfigLoader.java
@@ -19,6 +19,8 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.invoke.MethodHandles;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 
 import javax.xml.parsers.ParserConfigurationException;
@@ -52,7 +54,7 @@ public class SolrConfigLoader extends SolrResourceLoader {
      * Instantiate with the name of the configuration directory and the ZooKeeper used to access it.
      */
     public SolrConfigLoader(String collection, ZooKeeper zooKeeper) {
-        super("solr");
+        super(Paths.get("solr"));
         this.zk = zooKeeper;
         this.configZkPath = getCollectionConfigPath(collection);
     }

--- a/hbase-indexer-common/src/main/java/com/ngdata/hbaseindexer/util/solr/SolrTestingUtility.java
+++ b/hbase-indexer-common/src/main/java/com/ngdata/hbaseindexer/util/solr/SolrTestingUtility.java
@@ -34,7 +34,7 @@ import com.ngdata.hbaseindexer.util.MavenUtil;
 import com.ngdata.sep.util.zookeeper.ZkUtil;
 import com.ngdata.sep.util.zookeeper.ZooKeeperItf;
 import org.apache.commons.io.FileUtils;
-import org.apache.solr.client.solrj.SolrServer;
+import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.cloud.ZkController;
 import org.apache.solr.common.cloud.OnReconnect;
 import org.apache.solr.common.cloud.SolrZkClient;
@@ -115,7 +115,7 @@ public class SolrTestingUtility {
             String solrVersion = properties.getProperty("solr.version");
             return solrVersion;
         } else {
-            return SolrServer.class.getPackage().getSpecificationVersion();
+            return SolrClient.class.getPackage().getSpecificationVersion();
         }
     }
 

--- a/hbase-indexer-engine/src/main/java/com/ngdata/hbaseindexer/indexer/DirectSolrClassicInputDocumentWriter.java
+++ b/hbase-indexer-engine/src/main/java/com/ngdata/hbaseindexer/indexer/DirectSolrClassicInputDocumentWriter.java
@@ -168,7 +168,7 @@ public class DirectSolrClassicInputDocumentWriter implements SolrInputDocumentWr
     }
 
     /**
-     * Has the same behavior as {@link org.apache.solr.client.solrj.SolrServer#deleteByQuery(String)}.
+     * Has the same behavior as {@link org.apache.solr.client.solrj.SolrClient#deleteByQuery(String)}.
      *
      * @param deleteQuery delete query to be executed
      */
@@ -194,7 +194,11 @@ public class DirectSolrClassicInputDocumentWriter implements SolrInputDocumentWr
     @Override
     public void close() {
         for (SolrClient server : solrServers) {
-            server.shutdown();
+            try {
+                server.close();
+            } catch (IOException e) {
+                log.error("Error when closing SolrClient", e);
+            }
         }
     }
 

--- a/hbase-indexer-engine/src/main/java/com/ngdata/hbaseindexer/indexer/DirectSolrInputDocumentWriter.java
+++ b/hbase-indexer-engine/src/main/java/com/ngdata/hbaseindexer/indexer/DirectSolrInputDocumentWriter.java
@@ -168,7 +168,7 @@ public class DirectSolrInputDocumentWriter implements SolrInputDocumentWriter {
     }
     
     /**
-     * Has the same behavior as {@link SolrServer#deleteByQuery(String)}.
+     * Has the same behavior as {@link SolrClient#deleteByQuery(String)}.
      * 
      * @param deleteQuery delete query to be executed
      */
@@ -191,7 +191,11 @@ public class DirectSolrInputDocumentWriter implements SolrInputDocumentWriter {
     
     @Override
     public void close() {
-        solrServer.shutdown();
+        try {
+            solrServer.close();
+        } catch (IOException e) {
+            log.error("Error when closing SolrClient", e);
+        }
     }
 
 }

--- a/hbase-indexer-engine/src/main/java/com/ngdata/hbaseindexer/indexer/FusionDocumentWriter.java
+++ b/hbase-indexer-engine/src/main/java/com/ngdata/hbaseindexer/indexer/FusionDocumentWriter.java
@@ -27,9 +27,8 @@ import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.SolrInputField;
 
-import org.apache.solr.common.util.DateUtil;
-
 import java.io.IOException;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
@@ -216,7 +215,7 @@ public class FusionDocumentWriter implements SolrInputDocumentWriter {
                 key.equals("inc")) {
               // keep track of the time we saw this doc on the hbase side
               Map<String,String> atomicUpdateMap = new HashMap<String, String>();
-              atomicUpdateMap.put("set", DateUtil.getThreadLocalDateFormat().format(new Date()));
+              atomicUpdateMap.put("set", DateTimeFormatter.ISO_INSTANT.format(new Date().toInstant()));
               doc.addField("_hbasets_tdt", atomicUpdateMap);
 
               // The atomic update documents should be added to the atomicUpdateDocs...
@@ -368,7 +367,7 @@ public class FusionDocumentWriter implements SolrInputDocumentWriter {
         }
       }
       // keep track of the time we saw this doc on the hbase side
-      String tdt = DateUtil.getThreadLocalDateFormat().format(new Date());
+      String tdt = DateTimeFormatter.ISO_INSTANT.format(new Date().toInstant());
       fields.add(mapField("_hbasets_tdt", null, tdt));
       if (log.isDebugEnabled())
           log.debug(strIndexName + " Reconcile id = " + docId + " and timestamp = " + tdt );
@@ -538,7 +537,7 @@ public class FusionDocumentWriter implements SolrInputDocumentWriter {
     } catch (Exception ignore){}
 
     try {
-      solrProxy.shutdown();
+      solrProxy.close();
     } catch (Exception ignore){}
   }
 

--- a/hbase-indexer-mr/src/main/java/com/ngdata/hbaseindexer/mr/HBaseMapReduceIndexerTool.java
+++ b/hbase-indexer-mr/src/main/java/com/ngdata/hbaseindexer/mr/HBaseMapReduceIndexerTool.java
@@ -224,7 +224,7 @@ public class HBaseMapReduceIndexerTool extends Configured implements Tool {
         for (SolrClient server : servers) {
             server.deleteByQuery("*:*");
             server.commit(false, false);
-            server.shutdown();
+            server.close();
         }
     }
 
@@ -232,7 +232,7 @@ public class HBaseMapReduceIndexerTool extends Configured implements Tool {
         Set<SolrClient> servers = createSolrServers(indexConnectionParams);
         for (SolrClient server : servers) {
             server.commit(false, false);
-            server.shutdown();
+            server.close();
         }
     }
 

--- a/hbase-indexer-mr/src/test/java/org/apache/solr/hadoop/ForkedTestUtils.java
+++ b/hbase-indexer-mr/src/test/java/org/apache/solr/hadoop/ForkedTestUtils.java
@@ -54,7 +54,7 @@ public class ForkedTestUtils {
           long numDocs = resp.getResults().getNumFound();
           actualDocs += numDocs;
         } finally {
-          solr.shutdown();
+          solr.close();
         }
       }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <hdp.version></hdp.version>
     <!--hdp.version>.2.6.0.0-570</hdp.version-->
 
-    <version.solr>5.5.2</version.solr>
+    <version.solr>6.6.2</version.solr>
     <version.guava>11.0.2</version.guava>
     <version.joda-time>1.6</version.joda-time>
     <version.slf4j>1.7.5</version.slf4j>
@@ -1462,8 +1462,8 @@
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
           <configuration>
-            <source>1.6</source>
-            <target>1.6</target>
+            <source>1.8</source>
+            <target>1.8</target>
             <encoding>UTF-8</encoding>
           </configuration>
         </plugin>


### PR DESCRIPTION
- SOLR-8903 was the guide to fix problems with `DateUtil` class